### PR TITLE
Add elo

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -17,6 +17,8 @@ class GamesController < ApplicationController
       player.results.create!(game: game, win: winners.include?(player))
     end
 
+    RankingCalculatorService.rank(game)
+
     flash[:notice] = 'Game successfully created!'
 
     redirect_to '/'

--- a/app/controllers/slack_coordinator_controller.rb
+++ b/app/controllers/slack_coordinator_controller.rb
@@ -91,22 +91,12 @@ class SlackCoordinatorController < ApplicationController
       end
 
     when 'stats'
-      user_stats = StatRetrievalService.find(@user)
-      if user_stats[:rank]
-        json_result[:text] = "Rank: #{user_stats[:rank]}\n"
-      else
-        games_needed = @user.games_needed_to_rank
-        json_result[:text] = "#{@user} needs to play #{games_needed} more #{'game'.pluralize(games_needed)} to be ranked.\n"
-      end
-      json_result[:text] += "Wins: #{user_stats[:wins]}\tLosses: #{user_stats[:losses]}\n#{@user} has won #{user_stats[:win_ratio]*100}% of the games they have finished."
+      json_result[:text] = StatRetrievalService.stats_string(@user)
 
     when 'rankings'
-      rankings = StatRetrievalService.rankings
+      rankings = StatRetrievalService.rankings_string
       if rankings.present?
-        json_result[:text] = ''
-        rankings.each do |ranking_hash|
-          json_result[:text] += "#{ranking_hash[:rank]}\t#{ranking_hash[:slack_name]}\t#{ranking_hash[:wins]}-#{ranking_hash[:losses]}\n"
-        end
+        json_result[:text] = rankings
       else
         json_result[:text] = 'There are no ranked players yet.'
       end

--- a/app/controllers/slack_coordinator_controller.rb
+++ b/app/controllers/slack_coordinator_controller.rb
@@ -94,7 +94,7 @@ class SlackCoordinatorController < ApplicationController
       json_result[:text] = StatRetrievalService.stats_string(@user)
 
     when 'rankings'
-      rankings = StatRetrievalService.rankings_string
+      rankings = StatRetrievalService.rankings_string(limit: 15)
       if rankings.present?
         json_result[:text] = rankings
       else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   def index
-    @users = User.order(:slack_user_name).paginate(page: params[:page], per_page: 10)
+    @users = User.order('rank desc').paginate(page: params[:page], per_page: 50)
   end
 
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,4 @@
 class User < ActiveRecord::Base
-  GAMES_NEEDED_TO_RANK = 5
-
   has_many :results
 
   validates_presence_of :slack_user_id, :slack_user_name
@@ -23,14 +21,6 @@ class User < ActiveRecord::Base
 
   def games_lost
     games_finished - games_won
-  end
-
-  def ranked?
-    games_finished >= GAMES_NEEDED_TO_RANK
-  end
-
-  def games_needed_to_rank
-    games_finished >= GAMES_NEEDED_TO_RANK ? 0 : GAMES_NEEDED_TO_RANK - games_finished
   end
 
   def self.calculate_win_ratio(won, finished)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ActiveRecord::Base
   end
 
   def win_ratio
-    games_finished > 0 ? games_won.to_f / games_finished.to_f : 0
+    User.calculate_win_ratio(games_won, games_finished)
   end
 
   def games_lost
@@ -31,5 +31,10 @@ class User < ActiveRecord::Base
 
   def games_needed_to_rank
     games_finished >= GAMES_NEEDED_TO_RANK ? 0 : GAMES_NEEDED_TO_RANK - games_finished
+  end
+
+  def self.calculate_win_ratio(won, finished)
+    return 0 unless finished > 0
+    (won.to_f / finished * 100).round(2)
   end
 end

--- a/app/services/ranking_calculator_service.rb
+++ b/app/services/ranking_calculator_service.rb
@@ -21,16 +21,16 @@ class RankingCalculatorService
       #   ranked teammate counts as a more challenging game and vice versa.
       o_rank = opponent_1.rank + opponent_2.rank - teammate.rank
 
-      player.update_attributes(rank: new_elo(player.rank, o_rank, score))
+      player.update_attributes!(rank: new_elo(player.rank, o_rank, score))
     end
 
-    def new_elo(player, opponent, score)
+    def new_elo(player_rank, opponent_rank, score)
       # The player's ranking is affected by the K Factor times the chance they
       #   had of winning minus the actual result. E.g. if a player has a .75
       #   chance of winning, a K Factor of 32, and loses, they will lose 24
       #   points.
-      (player + k_factor(player) *
-        (score - expected_score(player, opponent))).round
+      (player_rank + k_factor(player_rank) *
+        (score - expected_score(player_rank, opponent_rank))).round
     end
 
     def expected_score(player_rank, opponent_rank)

--- a/app/services/ranking_calculator_service.rb
+++ b/app/services/ranking_calculator_service.rb
@@ -1,39 +1,63 @@
 class RankingCalculatorService
   class << self
-    K_VALUE = 32
-
     def rank(game)
       return unless game.finished?
 
       winners = game.winning_team
       losers = game.losing_team
 
-      # Each player is said to have played against the average elo of the
-      #   opposing team.
-      winner_elo = winners.map(&:elo_rating).inject(:+) / 2
-      loser_elo = losers.map(&:elo_rating).inject(:+) / 2
+      update_player(winners[0], winners[1], losers[0], losers[1], 1)
+      update_player(winners[1], winners[0], losers[0], losers[1], 1)
 
-      winners.each do |winner|
-        winner.update_attributes!(elo_rating: new_elo(winner.elo_rating, loser_elo, 1))
-      end
-
-      losers.each do |loser|
-        loser.update_attributes!(elo_rating: new_elo(loser.elo_rating, winner_elo, 0))
-      end
+      update_player(losers[0], losers[1], winners[0], winners[1], 0)
+      update_player(losers[1], losers[0], winners[0], winners[1], 0)
     end
 
     private
 
-    def new_elo(player_rank, opponent_rank, score)
-      (player_rank + K_VALUE * (score - expected_score(player_rank, opponent_rank))).round
+    def update_player(player, teammate, opponent_1, opponent_2, score)
+      # To account for the rank of the teammate, we sum the opponents then
+      #   subtract the rank of the teammate. This way, playing with a lower
+      #   ranked teammate counts as a more challenging game and vice versa.
+      o_rank = opponent_1.rank + opponent_2.rank - teammate.rank
+
+      player.update_attributes(rank: new_elo(player.rank, o_rank, score))
+    end
+
+    def new_elo(player, opponent, score)
+      # The player's ranking is affected by the K Factor times the chance they
+      #   had of winning minus the actual result. E.g. if a player has a .75
+      #   chance of winning, a K Factor of 32, and loses, they will lose 24
+      #   points.
+      (player + k_factor(player) *
+        (score - expected_score(player, opponent))).round
     end
 
     def expected_score(player_rank, opponent_rank)
+      # This determines, on a scale from 0.0 to 1.0, the chances a player has
+      #   of defeating a given opponent. This is used to determine what
+      #   percentage of the K Factor is applied or taken away at the end of
+      #   a match.
       q(player_rank).to_f / (q(player_rank) + q(opponent_rank))
     end
 
     def q(rank)
+      # 400 is arbitrary, but seems to be pretty universal among all the
+      #   implementations of ELO I've come across.
       10**(rank.to_f / 400)
+    end
+
+    def k_factor(player_rank)
+      # The K factor is the maximum value by which a given player's rating
+      #   can change in a given match. We will use USCF's logistic distribution
+      #   for determining K factor based on rating.
+      if player_rank < 2100
+        32
+      elsif player_rank < 2400
+        24
+      else
+        16
+      end
     end
   end
 end

--- a/app/services/ranking_calculator_service.rb
+++ b/app/services/ranking_calculator_service.rb
@@ -43,7 +43,7 @@ class RankingCalculatorService
 
     def q(rank)
       # 400 is arbitrary, but seems to be pretty universal among all the
-      #   implementations of ELO I've come across.
+      #   implementations of Elo's ranking system I've come across.
       10**(rank.to_f / 400)
     end
 

--- a/app/services/ranking_calculator_service.rb
+++ b/app/services/ranking_calculator_service.rb
@@ -1,0 +1,39 @@
+class RankingCalculatorService
+  class << self
+    K_VALUE = 32
+
+    def rank(game)
+      return unless game.finished?
+
+      winners = game.winning_team
+      losers = game.losing_team
+
+      # Each player is said to have played against the average elo of the
+      #   opposing team.
+      winner_elo = winners.map(&:elo_rating).inject(:+) / 2
+      loser_elo = losers.map(&:elo_rating).inject(:+) / 2
+
+      winners.each do |winner|
+        winner.update_attributes!(elo_rating: new_elo(winner.elo_rating, loser_elo, 1))
+      end
+
+      losers.each do |loser|
+        loser.update_attributes!(elo_rating: new_elo(loser.elo_rating, winner_elo, 0))
+      end
+    end
+
+    private
+
+    def new_elo(player_rank, opponent_rank, score)
+      (player_rank + K_VALUE * (score - expected_score(player_rank, opponent_rank))).round
+    end
+
+    def expected_score(player_rank, opponent_rank)
+      q(player_rank).to_f / (q(player_rank) + q(opponent_rank))
+    end
+
+    def q(rank)
+      10**(rank.to_f / 400)
+    end
+  end
+end

--- a/app/services/result_creation_service.rb
+++ b/app/services/result_creation_service.rb
@@ -16,6 +16,7 @@ class ResultCreationService
 
     if game.reload.finished?
       game.update_attributes!(finished_at: Time.zone.now)
+      RankingCalculatorService.rank(game)
     end
     result
   end

--- a/app/services/stat_retrieval_service.rb
+++ b/app/services/stat_retrieval_service.rb
@@ -19,10 +19,9 @@ class StatRetrievalService
         .join("\n")
     end
 
-    def rankings
+    def rankings(limit: 1000)
       ranked_users = []
-      User.order('rank desc').each do |u|
-        next unless u.ranked?
+      User.where('rank != 1500').order('rank desc').limit(limit).each do |u|
         wins = u.games_won
         losses = u.games_lost
         win_ratio = User.calculate_win_ratio(wins, wins + losses)
@@ -32,15 +31,13 @@ class StatRetrievalService
                           wins: wins,
                           losses: losses,
                           win_ratio: win_ratio }
-
-        return ranked_users if ranked_users.size > 20
       end
       ranked_users
     end
 
-    def rankings_string
+    def rankings_string(limit: 1000)
       result = ''
-      rankings.each do |r|
+      rankings(limit: limit).each do |r|
         result += [r[:rank],
                    r[:slack_name],
                    "#{r[:wins]}-#{r[:losses]}"].join("\t")

--- a/app/views/home/_rankings_table.html.erb
+++ b/app/views/home/_rankings_table.html.erb
@@ -14,7 +14,7 @@
           </tr>
         </thead>
         <tbody>
-          <% StatRetrievalService.rankings.each do |ranking| %>
+          <% StatRetrievalService.rankings(limit: 20).each do |ranking| %>
             <tr>
               <td></td>
               <td><%= ranking[:rank] %></td>

--- a/app/views/home/_rankings_table.html.erb
+++ b/app/views/home/_rankings_table.html.erb
@@ -6,9 +6,9 @@
         <thead>
           <tr>
             <th></th>
-            <th></th>
+            <th>Elo</th>
             <th>User Name</th>
-            <th>Win Ratio</th>
+            <th>Win Percentage</th>
             <th>Wins</th>
             <th>Losses</th>
           </tr>
@@ -19,7 +19,7 @@
               <td></td>
               <td><%= ranking[:rank] %></td>
               <td><%= link_to ranking[:slack_name], user_path(ranking[:slack_name]) %></td>
-              <td><%= ranking[:win_ratio] %></td>
+              <td><%= ranking[:win_ratio] %>%</td>
               <td><%= ranking[:wins] %></td>
               <td><%= ranking[:losses] %></td>
             </tr>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -6,6 +6,7 @@
       <thead>
         <tr>
           <th>User Name</th>
+          <th>Elo Rank</th>
           <th>Win Ratio</th>
           <th>Wins</th>
           <th>Losses</th>
@@ -16,6 +17,7 @@
           <% stats = StatRetrievalService.find(user) %>
           <tr>
             <td><%= link_to user.slack_user_name, user_path(user.slack_user_name) %></td>
+            <td><%= stats[:rank] == 1500 ? 'Unranked' : stats[:rank] %></td>
             <td><%= stats[:win_ratio] %></td>
             <td><%= stats[:wins] %></td>
             <td><%= stats[:losses] %></td>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,4 @@
 <h2 class='header'><%= @user.slack_user_name %></h2>
 <div class='card-panel'>
-  <p class='flow-text'><%= @user.slack_user_name.capitalize %> has played a total of <%= @stats[:wins] + @stats[:losses] %> games, winning <%= @stats[:wins] > 0 ? @stats[:wins] : 'none' %> and losing <%= @stats[:losses] > 0 ? @stats[:losses] : 'none' %> for a win ratio of approximately <%= @stats[:win_ratio] %>. Their ELO rank is <%= @user.rank %>.</p>
+  <p class='flow-text'><%= @user.slack_user_name.capitalize %> has played a total of <%= @stats[:wins] + @stats[:losses] %> games, winning <%= @stats[:wins] > 0 ? @stats[:wins] : 'none' %> and losing <%= @stats[:losses] > 0 ? @stats[:losses] : 'none' %> for a win ratio of approximately <%= @stats[:win_ratio] %>. Their Elo rank is <%= @user.rank %>.</p>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,4 @@
 <h2 class='header'><%= @user.slack_user_name %></h2>
 <div class='card-panel'>
-  <p class='flow-text'><%= @user.slack_user_name.capitalize %> has played a total of <%= @stats[:wins] + @stats[:losses] %> games, winning <%= @stats[:wins] > 0 ? @stats[:wins] : 'none' %> and losing <%= @stats[:losses] > 0 ? @stats[:losses] : 'none' %> for a win ratio of approximately <%= @stats[:win_ratio] %>.</p>
+  <p class='flow-text'><%= @user.slack_user_name.capitalize %> has played a total of <%= @stats[:wins] + @stats[:losses] %> games, winning <%= @stats[:wins] > 0 ? @stats[:wins] : 'none' %> and losing <%= @stats[:losses] > 0 ? @stats[:losses] : 'none' %> for a win ratio of approximately <%= @stats[:win_ratio] %>. Their ELO rank is <%= @user.elo_rating %>.</p>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,4 @@
 <h2 class='header'><%= @user.slack_user_name %></h2>
 <div class='card-panel'>
-  <p class='flow-text'><%= @user.slack_user_name.capitalize %> has played a total of <%= @stats[:wins] + @stats[:losses] %> games, winning <%= @stats[:wins] > 0 ? @stats[:wins] : 'none' %> and losing <%= @stats[:losses] > 0 ? @stats[:losses] : 'none' %> for a win ratio of approximately <%= @stats[:win_ratio] %>. Their ELO rank is <%= @user.elo_rating %>.</p>
+  <p class='flow-text'><%= @user.slack_user_name.capitalize %> has played a total of <%= @stats[:wins] + @stats[:losses] %> games, winning <%= @stats[:wins] > 0 ? @stats[:wins] : 'none' %> and losing <%= @stats[:losses] > 0 ? @stats[:losses] : 'none' %> for a win ratio of approximately <%= @stats[:win_ratio] %>. Their ELO rank is <%= @user.rank %>.</p>
 </div>

--- a/db/migrate/20150802001305_add_rating_to_user.rb
+++ b/db/migrate/20150802001305_add_rating_to_user.rb
@@ -1,0 +1,5 @@
+class AddRatingToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :elo_rating, :integer, null: false, default: 1500
+  end
+end

--- a/db/migrate/20150802001305_add_rating_to_user.rb
+++ b/db/migrate/20150802001305_add_rating_to_user.rb
@@ -1,5 +1,11 @@
 class AddRatingToUser < ActiveRecord::Migration
-  def change
-    add_column :users, :elo_rating, :integer, null: false, default: 1500
+  def up
+    add_column :users, :rank, :integer, null: false, default: 1500
+
+    Game.order(:started_at).each { |g| RankingCalculatorService.rank(g) }
+  end
+
+  def down
+    remove_column :users, :rank
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -37,7 +37,7 @@ ActiveRecord::Schema.define(version: 20150802001305) do
     t.string   "slack_user_name",                null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "elo_rating",      default: 1500, null: false
+    t.integer  "rank",            default: 1500, null: false
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150724040532) do
+ActiveRecord::Schema.define(version: 20150802001305) do
 
   create_table "games", force: true do |t|
     t.datetime "finished_at"
@@ -33,10 +33,11 @@ ActiveRecord::Schema.define(version: 20150724040532) do
   add_index "results", ["user_id"], name: "fk_results_user_id_users", using: :btree
 
   create_table "users", force: true do |t|
-    t.string   "slack_user_id",   null: false
-    t.string   "slack_user_name", null: false
+    t.string   "slack_user_id",                  null: false
+    t.string   "slack_user_name",                null: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "elo_rating",      default: 1500, null: false
   end
 
 end

--- a/test/services/ranking_calculator_test.rb
+++ b/test/services/ranking_calculator_test.rb
@@ -1,8 +1,0 @@
-require 'test_helper'
-
-class RankingCalculatorTest < ActiveSupport::TestCase
-  def test_validates_presence_of_slack_user_id_and_name
-    puts RankingCalculatorService.expected_score(2200, 1000)
-    puts RankingCalculatorService.new_elo(1601, 1622, 0)
-  end
-end

--- a/test/services/ranking_calculator_test.rb
+++ b/test/services/ranking_calculator_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class RankingCalculatorTest < ActiveSupport::TestCase
+  def test_validates_presence_of_slack_user_id_and_name
+    puts RankingCalculatorService.expected_score(1600, 2200)
+    puts RankingCalculatorService.new_elo(1601, 1622, 0)
+  end
+end

--- a/test/services/ranking_calculator_test.rb
+++ b/test/services/ranking_calculator_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class RankingCalculatorTest < ActiveSupport::TestCase
   def test_validates_presence_of_slack_user_id_and_name
-    puts RankingCalculatorService.expected_score(1600, 2200)
+    puts RankingCalculatorService.expected_score(2200, 1000)
     puts RankingCalculatorService.new_elo(1601, 1622, 0)
   end
 end


### PR DESCRIPTION
So here it is. Elo is calculated at the end of each game and stored on the user. Rankings are now sorted by Elo, and it's displayed in `.stats`. I'm pretty happy with the modified algorithm for multiplayer games, in that it takes into account the teammates skills as well (so you're punished less for playing with an unskilled player, and rewarded less for being carried to victory).

Definitely run the migration on a test db first, it works on the dump you gave me but who knows. Also I didn't have a way of testing the `.stats` and `.rankings` commands, so I pulled the string building out into the service where I could run it in the rails console. Probably test that too :smile:.

Fixes #4 